### PR TITLE
some refactoring and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+*.iml
+.idea

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Clojure library that wraps the wiremock Java library
 Add the following to your `project.clj` file:
 
 ```clj
-[b-social/wiremock-wrapper "0.1.0"]
+[b-social/wiremock-wrapper "0.2.0"]
 ```
 
 ## Documentation
@@ -16,7 +16,68 @@ Add the following to your `project.clj` file:
 
 ## Usage
 
-FIXME
+```clojure
+(let [wire-mock-server (wiremock/new-wire-mock-server)
+      test-system (atom (test-system/new-test-system
+                          :core-banking-gateway
+                          (config/core-banking-gateway-configuration
+                            {:core-banking-gateway-base-url
+                             ;; A convenient way to define base url for service:
+                             ;; e.g. http://localhost:[WIREMOCK_PORT]/core-banking
+                             ;; So it's easy to use same WireMock for multiple services with different base url path
+                             (service-mock-base-url
+                               wire-mock-server
+                               :core-banking)})))]
+
+  (use-fixtures :once
+                (wiremock/with-wire-mock-server wire-mock-server)
+                (test-system/with-system-lifecycle test-system))
+  (use-fixtures :each
+                (with-empty-database test-system)
+                ;; Reset WireMock after each test: mocks, requests journal, etc
+                (wiremock/with-empty-wire-mock-server wire-mock-server)
+                ;; It will fail a test if any unexpected request was made to the WireMock server
+                ;; Could potentially catch additional hard to detect bugs
+                (wiremock/with-verify-nounmatched wire-mock-server))
+
+  (deftest test-example
+    (let [deposit-id (data/random-uuid)]
+
+      ;; Note: it's not creating a new nesting layer
+      ;; All mocks are available on the server until it's cleared by fixture
+      (configure-mocks-on
+        wire-mock-server
+        [
+         ;;
+         ;; Discovery stub example
+         {:request {:urlPath "/core-banking"
+                    :method "GET"
+                    :headers {"Content-Type" {:equalTo "application/json"}
+                              "Accept" {:equalTo "application/hal+json"}}}
+          :response {:status 200
+                     ;; real body here
+                     :body (-> {} (resource->json))}}
+
+         ;; Deposit stub example
+         {:request {:url (str "/core-banking/deposits/" deposit-id)
+                    :method "PUT"
+                    ;; common header are defined as a constant in the wiremock-wrapper library
+                    :headers wiremock-wrapper/COMMON-HEADERS
+                    :bodyPatterns [{:equalToJson {:amount 1}
+                                    :ignoreExtraElements true}]}
+          :response {:status 201}}])
+
+      ;; Test body goes here
+      ;; And all assertions here
+
+      ;; Good idea to include check for expected N of calls,
+      ;; to prevent issue if there were more requests to a same endpoint
+      ;; than expected
+      (testing "Expected number of request to the WireMock server"
+        (is (= 2 (-> (wiremock/get-requests-from @wire-mock-server)
+                     (get "requests")
+                     (count))))))))
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,30 @@ Add the following to your `project.clj` file:
                      (count))))))))
 ```
 
+## Debugging
+In case of stubs not match, WireMock provides useful logs, e.g.:
+```
+5366377 [qtp1955035115-183] ERROR WireMock -
+                                               Request was not matched
+                                               =======================
+
+-----------------------------------------------------------------------------------------------------------------------
+| Closest stub                                             | Request                                                  |
+-----------------------------------------------------------------------------------------------------------------------
+                                                           |
+GET                                                        | GET
+/core-baking                                               | /core-banking                                       <<<<< URL does not match
+                                                           |
+Content-Type: application/json                             | Content-Type: application/json
+Accept: application/hal+json                               | Accept: application/hal+json
+                                                           |
+                                                           |
+-----------------------------------------------------------------------------------------------------------------------
+
+```
+So we know in this case that we've made a typo. If this logs are now visible, usually it means that logback wasn't configured properly in test.
+Compare it with this one (which should work), usually missing STDOUT appender: https://github.com/b-social/internal-payment-service/blob/master/test/shared/logback-test.xml#L34
+
 ## License
 
 Copyright © 2020 Kroo Ltd

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject b-social/wiremock-wrapper "0.1.0"
+(defproject b-social/wiremock-wrapper "0.2.0"
   :description "A clojure wrapper library around Java wiremock library"
   :url "https://github.com/b-social/wiremock-wrapper"
   :license {:name "The MIT License"
@@ -7,9 +7,7 @@
                  [http-kit "2.3.0"]
                  [freeport "1.0.0"]
                  [b-social/jason "0.1.5"]
-                 [com.github.tomakehurst/wiremock "2.24.1"]]
+                 [com.github.tomakehurst/wiremock "2.27.2"]]
   :deploy-repositories
   {"releases" {:url "https://repo.clojars.org" :creds :gpg}}
   :repl-options {:init-ns wiremock-wrapper})
-
-

--- a/src/wiremock_wrapper.clj
+++ b/src/wiremock_wrapper.clj
@@ -7,6 +7,12 @@
     [com.github.tomakehurst.wiremock WireMockServer]
     [com.github.tomakehurst.wiremock.core WireMockConfiguration]))
 
+(def COMMON-HEADERS {"Content-Type" {:equalTo "application/json"}
+                     "Accept" {:equalTo "application/hal+json"}})
+
+(def ADMIN-AUTH-HEADERS
+  (merge COMMON-HEADERS
+         {"Authorization" {:equalTo "ADMIN"}}))
 
 (declare
   ->wire-json
@@ -14,17 +20,23 @@
 
 (defcoders wire)
 
-(defn wire-mock-config
-  ([] (wire-mock-config (get-free-port!)))
-  ([port] (.port (WireMockConfiguration/options) port)))
-
 (defn new-wire-mock-server
-  ([] (new-wire-mock-server (wire-mock-config)))
-  ([config] (atom (new WireMockServer config))))
+  []
+  (->> (get-free-port!)
+       (.port (WireMockConfiguration/options))
+       (new WireMockServer)
+       (atom)))
 
-(defn base-url [wire-mock-server-port]
-  (format "http://localhost:%s"
-    wire-mock-server-port))
+(defn base-url
+  [wire-mock-server-atom]
+  (str "http://localhost:"
+       (.portNumber (.getOptions @wire-mock-server-atom))))
+
+(defn service-mock-base-url
+  [wire-mock-server-atom service-name]
+  (str (base-url wire-mock-server-atom)
+       "/"
+       (name service-name)))
 
 (defn url [wire-mock-server path]
   (.url wire-mock-server path))
@@ -53,11 +65,16 @@
 (defn reset [wire-mock-server]
   @(http/post (reset-url wire-mock-server)))
 
-(defn configure-mocks-on [wire-mock-server mocks]
+(defn configure-mocks-on
+  [wire-mock-server-atom mocks]
   (doseq [mock mocks]
-    (let [mapping (->wire-json mock)]
-      @(http/post (mappings-url wire-mock-server)
-         {:body mapping}))))
+    (let [response (-> (mappings-url @wire-mock-server-atom)
+                       (http/post {:body (->wire-json mock)})
+                       (deref))]
+      (when-not (= (:status response) 201)
+        (->> response
+             (ex-info "Error while adding mapping to WireMock server")
+             (throw))))))
 
 (defn get-mappings-from [wire-mock-server]
   (let [response @(http/get (mappings-url wire-mock-server))
@@ -84,11 +101,13 @@
     (when-not (zero? (count (get body "requests")))
       (throw (ex-info "There were unmatched requests" body)))))
 
-(defn respond-with [response]
+(defn ^:deprecated respond-with
+  [response]
   (fn [mapping]
     (assoc mapping :response response)))
 
-(defn on-request [request & others]
+(defn ^:deprecated on-request
+  [request & others]
   (fn [mapping]
     (reduce
       (fn [m o] (o m))
@@ -120,10 +139,14 @@
       (finally
         (stop @wire-mock-server-atom)))))
 
-(defmacro with-http-mocks [wire-mock-server-atom mocks & body]
+;; Don't use the macro, use configure-mocks-on directly
+;; Macro doesn't create a new scope where mocks are registered on server
+;; They will be there even outside the macro, so it's just adding a new nested level
+(defmacro ^:deprecated with-http-mocks
+  [wire-mock-server-atom mocks & body]
   `(do
      (configure-mocks-on
-       (deref ~wire-mock-server-atom)
+       ~wire-mock-server-atom
        (flatten (map #(% {}) ~mocks)))
      ~@body))
 

--- a/test/wiremock_wrapper/core_test.clj
+++ b/test/wiremock_wrapper/core_test.clj
@@ -1,20 +1,19 @@
 (ns wiremock-wrapper.core-test
-  (:require [clojure.test :refer :all]
-            [freeport.core :refer [get-free-port!]]
+  (:require [clojure.test :refer [use-fixtures
+                                  deftest
+                                  is
+                                  testing]]
             [org.httpkit.client :as http-kit]
-            [wiremock-wrapper :refer :all]
+            [wiremock-wrapper :as wiremock-wrapper]
             [jason.convenience :as jason]))
 
-
-(let [wire-mock-server-port (get-free-port!)
-      wire-mock-config (wire-mock-config wire-mock-server-port)
-      wire-mock-server (new-wire-mock-server wire-mock-config)
-      wire-mock-address (base-url wire-mock-server-port)]
+(let [wire-mock-server-atom (wiremock-wrapper/new-wire-mock-server)
+      wire-mock-address (wiremock-wrapper/base-url wire-mock-server-atom)]
   (use-fixtures :once
-    (with-wire-mock-server wire-mock-server))
+    (wiremock-wrapper/with-wire-mock-server wire-mock-server-atom))
   (use-fixtures :each
-    (with-empty-wire-mock-server wire-mock-server)
-    (with-verify-nounmatched wire-mock-server))
+    (wiremock-wrapper/with-empty-wire-mock-server wire-mock-server-atom)
+    (wiremock-wrapper/with-verify-nounmatched wire-mock-server-atom))
 
   (deftest wrapper
     (let [url-1 "/url-1"
@@ -23,78 +22,74 @@
           unmatched-url "/unmatched-url"
           param "param"
           value "value"]
-      (with-http-mocks wire-mock-server
-        [(on-request
-           {:method "GET"
-            :url    url-1}
-           (respond-with
-             {:status 200}))
-         (on-request
-           {:method          "GET"
-            :urlPathPattern  url-2
-            :queryParameters {:random-param {:equalTo param}}}
-           (respond-with
-             {:status 200}))
-         (on-request
-           {:method       "POST"
-            :url          url-3
-            :bodyPatterns [{:equalToJson {:random value}}]}
-           (respond-with
-             {:status 201}))]
+      (wiremock-wrapper/configure-mocks-on
+        wire-mock-server-atom
+        [{:request {:method "GET"
+                    :url    url-1}
+          :response {:status 200}}
+         {:request {:method          "GET"
+                    :urlPathPattern  url-2
+                    :queryParameters {:random-param {:equalTo param}}}
+          :response {:status 200}}
+         {:request {:method       "POST"
+                    :url          url-3
+                    :bodyPatterns [{:equalToJson {:random value}}]}
+          :response {:status 201}}])
 
-        @(http-kit/get (str wire-mock-address url-1))
+      @(http-kit/get (str wire-mock-address url-1))
 
-        @(http-kit/get (str wire-mock-address url-2)
-           {:query-params {:random-param param}})
-        @(http-kit/post (str wire-mock-address url-3)
-           {:body (jason/->wire-json {:random value})})
+      @(http-kit/get (str wire-mock-address url-2)
+                     {:query-params {:random-param param}})
 
-        (testing "server has been called three times"
-          (is (true? (verify
-                       @wire-mock-server
-                       {:method "GET"
-                        :url    url-1})))
-          (is (true? (verify
-                       @wire-mock-server
-                       {:method          "GET"
-                        :urlPathPattern  url-2
-                        :queryParameters {:random-param {:equalTo param}}})))
-          (is (true? (verify
-                       @wire-mock-server
-                       {:method       "POST"
-                        :url          url-3
-                        :bodyPatterns [{:equalToJson {:random value}}]})))
-          (is (true? (verify
-                       @wire-mock-server
-                       {:method       "POST"
-                        :url          unmatched-url} 0)))))))
+      @(http-kit/post (str wire-mock-address url-3)
+                      {:body (jason/->wire-json {:random value})})
+
+      (testing "server has been called three times"
+        (is (true? (wiremock-wrapper/verify
+                     @wire-mock-server-atom
+                     {:method "GET"
+                      :url    url-1})))
+        (is (true? (wiremock-wrapper/verify
+                     @wire-mock-server-atom
+                     {:method          "GET"
+                      :urlPathPattern  url-2
+                      :queryParameters {:random-param {:equalTo param}}})))
+        (is (true? (wiremock-wrapper/verify
+                     @wire-mock-server-atom
+                     {:method       "POST"
+                      :url          url-3
+                      :bodyPatterns [{:equalToJson {:random value}}]})))
+        (is (true? (wiremock-wrapper/verify
+                     @wire-mock-server-atom
+                     {:method       "POST"
+                      :url          unmatched-url} 0))))))
 
   (deftest wrapper-scenarios
     (let [url-1 "/url-1"
           url-2 "/url-2"
           param "param"]
-      (with-http-mocks wire-mock-server
-        [(on-request
+      (wiremock-wrapper/with-http-mocks wire-mock-server-atom
+        [(wiremock-wrapper/on-request
            {:method "GET"
             :url    url-1}
-           (respond-with
+           (wiremock-wrapper/respond-with
              {:status 200}))
-         (on-request
+         (wiremock-wrapper/on-request
            {:method       "POST"
             :url          url-2
             :bodyPatterns [{:equalToJson {:random param}}]}
-           (in-scenario "Scenario 1")
-           (in-state "Started")
-           (respond-with {:status 503})
-           (move-to-state "passing"))
+           (wiremock-wrapper/in-scenario "Scenario 1")
+           (wiremock-wrapper/in-state "Started")
+           (wiremock-wrapper/respond-with {:status 503})
+           (wiremock-wrapper/move-to-state "passing"))
 
-         (on-request
+         (wiremock-wrapper/on-request
            {:method       "POST"
             :url          url-2
             :bodyPatterns [{:equalToJson {:random param}}]}
-           (in-scenario "Scenario 1")
-           (in-state "passing")
-           (respond-with {:status 201}))]
+           (wiremock-wrapper/in-scenario "Scenario 1")
+           (wiremock-wrapper/in-state "passing")
+           (wiremock-wrapper/respond-with {:status 201}))]
 
         @(http-kit/get (str wire-mock-address url-1))
 
@@ -104,12 +99,12 @@
            {:body (jason/->wire-json {:random param})})
 
         (testing "server has been called three times"
-          (is (true? (verify
-                       @wire-mock-server
+          (is (true? (wiremock-wrapper/verify
+                       @wire-mock-server-atom
                        {:method "GET"
                         :url    url-1})))
-          (is (true? (verify
-                       @wire-mock-server
+          (is (true? (wiremock-wrapper/verify
+                       @wire-mock-server-atom
                        {:method          "POST"
                         :urlPathPattern  url-2
                         :bodyPatterns [{:equalToJson {:random param}}]}

--- a/test/wiremock_wrapper/unit_test.clj
+++ b/test/wiremock_wrapper/unit_test.clj
@@ -1,22 +1,18 @@
-
 (ns wiremock-wrapper.unit-test
-  (:require [clojure.test :refer :all]
-            [freeport.core :refer [get-free-port!]]
+  (:require [clojure.test :refer [use-fixtures
+                                  deftest is]]
             [org.httpkit.client :as http-kit]
-            [wiremock-wrapper :refer :all])
+            [wiremock-wrapper :as wiremock-wrapper])
   (:import [clojure.lang ExceptionInfo]))
 
-(let [wire-mock-server-port (get-free-port!)
-      wire-mock-config (wire-mock-config wire-mock-server-port)
-      wire-mock-server (new-wire-mock-server wire-mock-config)
-      wire-mock-address (base-url wire-mock-server-port)]
+(let [wire-mock-server-atom (wiremock-wrapper/new-wire-mock-server)
+      wire-mock-address (wiremock-wrapper/base-url wire-mock-server-atom)]
   (use-fixtures :once
-    (with-wire-mock-server wire-mock-server))
+                (wiremock-wrapper/with-wire-mock-server wire-mock-server-atom))
   (use-fixtures :each
-    (with-empty-wire-mock-server wire-mock-server))
+                (wiremock-wrapper/with-empty-wire-mock-server wire-mock-server-atom))
   (deftest unmatched-url-throws-exception
-
     (is (thrown? ExceptionInfo
-          ((with-verify-nounmatched wire-mock-server)
-            (fn []  @(http-kit/get (str wire-mock-address "/url"))))))))
+                 ((wiremock-wrapper/with-verify-nounmatched wire-mock-server-atom)
+                  (fn []  @(http-kit/get (str wire-mock-address "/url"))))))))
 


### PR DESCRIPTION
Hi, I think that could simplify usage of the library a bit:
1. Fixed the issue when on-register new mock WireMock response wasn't 201, but the test wasn't failing at that point, and it was confusing to see that no stubs are registered. 
2. Simplified server creating in the test, no need to provide port:
```
;; before:
(let [wire-mock-server-port (get-free-port!)
      wire-mock-config (wire-mock-config wire-mock-server-port)
      wire-mock-server (new-wire-mock-server wire-mock-config)
      wire-mock-address (base-url wire-mock-server-port)]

;; now:
(let [wire-mock-server-atom (wiremock-wrapper/new-wire-mock-server)
      wire-mock-address (wiremock-wrapper/base-url wire-mock-server-atom)]
```
3. An fn to generate baseUrl for a service, in case we want serviceA and serviceB:
```
(let [service-a-base-url (service-mock-base-url wire-mock-server :service-a)
        service-b-base-url (service-mock-base-url wire-mock-server :service-b)])
```
4. Deprecated the with-mocks macro, check comment in the source, configure-mocks-on should be used directly IMO
5. Added usage example in the README
6. Example of WireMock debug log in README and logback config.